### PR TITLE
Added option to skip successful build notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,11 @@ Do not notify on the first build.  This allows you to receive notifications on s
 ```js
 new WebpackNotifierPlugin({skipFirstNotification: true});
 ```
+
+### Skip Notification for successfull builds
+
+Skip notifications for successful builds.
+
+```js
+new WebpackNotifierPlugin({skipSuccessful: true});
+```

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ ForkTsCheckerNotifierWebpackPlugin.prototype.buildNotification = function (norma
                 message: firstWarning.getContent()
             });
         }
-    } else if (!this.lastBuildSucceeded || this.options.alwaysNotify) {
+    } else if (!this.options.skipSuccessful && (!this.lastBuildSucceeded || this.options.alwaysNotify)) {
         this.lastBuildSucceeded = true;
         notification = Object.assign({}, messageTemplates.buildSucceeded, {
             title: util.format(messageTemplates.buildSucceeded.title, this.titlePrefix)


### PR DESCRIPTION
First of all thanks for the great plugin.

While I understand that you wanted to keep the same options as the webpack-notifier, in our case it really lacks option to skip successful build notifications at all.

So I propose to add such option. Will only notify on errors.