### PR TITLE
fix Cannot find module './types/NormalizedMessage'

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .vscode
 index.ts
+index.d.ts
 index.test.ts
 index.test.d.ts
 types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.2
+
+- [Fix TypeScript compiler complains about unknown module `NormalizedMessage`](https://github.com/johnnyreilly/fork-ts-checker-notifier-webpack-plugin/pull/8) - thanks @n0v1!
+
 ## v0.6.1
 
  - Updated README and added try/catch for forkTsCheckerReceive - thanks @Rolandisimo!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-notifier-webpack-plugin",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "a notifier for users of fork-ts-checker-webpack-plugin",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Add index.d.ts to [.npmignore](.npmignore) to prevent TypeScript compiler from complaining that it can not find './types/NormalizedMessage'. (npm package does not contain the `types` folder as it is also ignored in this .npmignore file)

This should fix the following error when using `fork-ts-checker-notifier-webpack-plugin` in a project:
```bash
ERROR in node_modules/fork-ts-checker-notifier-webpack-plugin/index.d.ts(1,35):
TS2307: Cannot find module './types/NormalizedMessage'.
```