### PR TITLE
Replacing `node-notifier` with `toasted-notifier` for enhanced notifications. Fixed #73

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ npm-debug.log
 index.js
 index.d.ts
 coverage
+
+# Include the types folder
+!types/
+!types/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v10.0.0
+
+- Replaced `node-notifier` with `toasted-notifier` for improved desktop notifications
+- `toasted-notifier` is a fork of `node-notifier` with additional features and fixes (works natively on Apple Silicon Macs)
+
+**BREAKING CHANGES**
+
+This migrates from `node-notifier` to `toasted-notifier` which is a fork with improved functionality. The API remains the same, but the underlying notification mechanism has changed.
+
 ## v9.0.0
 
 - [Update to support `fork-ts-checker-webpack-plugin` v9](https://github.com/johnnyreilly/fork-ts-checker-notifier-webpack-plugin/pull/65)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![build](https://travis-ci.com/johnnyreilly/fork-ts-checker-notifier-webpack-plugin.svg?branch=master)](https://travis-ci.com/johnnyreilly/fork-ts-checker-notifier-webpack-plugin/)
 [![node version](https://img.shields.io/node/v/fork-ts-checker-notifier-webpack-plugin.svg)](https://www.npmjs.com/package/fork-ts-checker-notifier-webpack-plugin)
 
-This is a [webpack](http://webpack.github.io/) plugin that uses the [node-notifier](https://github.com/mikaelbr/node-notifier) package to display build status system notifications to the user. It's purpose is to work with the [fork-ts-checker-webpack-plugin](https://github.com/Realytics/fork-ts-checker-webpack-plugin). This deliberately has a similar API as the excellent [webpack-notifier](https://github.com/Turbo87/webpack-notifier) plugin. If you are not using fork-ts-checker-webpack-plugin and you want system notifications then you probably want webpack-notifier.
+This is a [webpack](http://webpack.github.io/) plugin that uses the [toasted-notifier](https://github.com/Aetherinox/toasted-notifier) package to display build status system notifications to the user. It's purpose is to work with the [fork-ts-checker-webpack-plugin](https://github.com/Realytics/fork-ts-checker-webpack-plugin). This deliberately has a similar API as the excellent [webpack-notifier](https://github.com/Turbo87/webpack-notifier) plugin. If you are not using fork-ts-checker-webpack-plugin and you want system notifications then you probably want webpack-notifier.
 
 The plugin will notify you about the first run (success/fail), all failed runs and the first successful run after recovering from
 a build failure. In other words: it will stay silent if everything is fine with your build.

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import notifier from 'node-notifier';
+import toasted from 'toasted-notifier';
 import util from 'util';
 import forkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import type { Issue } from 'fork-ts-checker-webpack-plugin/lib/issue';
@@ -92,7 +92,7 @@ class ForkTsCheckerNotifierWebpackPlugin {
   compilationDone = (issues: Issue[]): Issue[] => {
     const notification = this.buildNotification(issues);
     if (notification) {
-      notifier.notify(notification);
+      toasted.notify(notification);
     }
     return issues;
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-ts-checker-notifier-webpack-plugin",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "a notifier for users of fork-ts-checker-webpack-plugin",
   "main": "index.js",
   "types": "index.d.ts",
@@ -29,7 +29,7 @@
     "url": "https://github.com/johnnyreilly/fork-ts-checker-notifier-webpack-plugin/issues"
   },
   "dependencies": {
-    "node-notifier": "^10.0.1"
+    "toasted-notifier": "^10.0.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "esModuleInterop": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "declaration": true
+    "declaration": true,
+    "typeRoots": ["./node_modules/@types", "./types"]
   },
   "files": ["index.ts"]
 }

--- a/types/toasted-notifier/index.d.ts
+++ b/types/toasted-notifier/index.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="node-notifier" />
+
+declare module 'toasted-notifier' {
+  import nodeNotifier = require('node-notifier');
+  export = nodeNotifier;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3086,18 +3086,6 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-notifier@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-10.0.1.tgz#0e82014a15a8456c4cfcdb25858750399ae5f1c7"
-  integrity sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==
-  dependencies:
-    growly "^1.3.0"
-    is-wsl "^2.2.0"
-    semver "^7.3.5"
-    shellwords "^0.1.1"
-    uuid "^8.3.2"
-    which "^2.0.2"
-
 node-releases@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
@@ -3425,6 +3413,11 @@ semver@^7.5.3, semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.6.0:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
 serialize-javascript@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
@@ -3629,6 +3622,18 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+toasted-notifier@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/toasted-notifier/-/toasted-notifier-10.0.2.tgz#25f467fa884e2de6bbcd21dc173987d179de7553"
+  integrity sha512-FDHgcMFCWU16BzEgNpoIyYz9f86kB5facdnAL4BuBZ3NG95bvt/ldyYA9HanxvwJjHse4ehx4jLQiY4LUoKKew==
+  dependencies:
+    growly "^1.3.0"
+    is-wsl "^2.2.0"
+    semver "^7.6.0"
+    shellwords "^0.1.1"
+    uuid "^9.0.1"
+    which "^2.0.2"
+
 ts-api-utils@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
@@ -3705,10 +3710,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-to-istanbul@^9.0.1:
   version "9.1.0"


### PR DESCRIPTION
 Add type definitions for `toasted-notifier` and adjust TypeScript configuration.